### PR TITLE
include errormessage when you use domain\username or username@domain …

### DIFF
--- a/psbbix.psm1
+++ b/psbbix.psm1
@@ -131,6 +131,8 @@ Function New-ZabbixSession {
     
 	# if (!$psboundparameters.count) {Get-Help -ex $PSCmdlet.MyInvocation.MyCommand.Name | out-string | Remove-EmptyLines; return}
 
+	if ($PSCredential.UserName.Contains("\") -or $PSCredential.UserName.Contains("@")) {write-host "Please omit the domain from the username when you use ldap authentication`n" -f red; return}
+
 	$Body = @{
 	    jsonrpc = "2.0"
 	    method = "user.login"


### PR DESCRIPTION
Our zabbix server uses ldap authentication and I wasn't able to login using username@domain or domain\username. Seems like the api only requires the username. So I added an errormessage.